### PR TITLE
Update ktlint and pass on options from pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 -   id: ktlint
-    name: Ktlint formatter for your kotlin code 
+    name: ktlint
     description: Runs ktlint over your kotlin files
     entry: ./run-ktlint.sh
     language: script

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ repos:
       - id: ktlint
 ```
 
+If you want to make use of the formatting functionality of ktlint you can configure
+the hook as follows:
+repos:
+- repo: https://github.com/maltzj/ktlint-pre-commit
+  sha: master
+  hooks:
+      - id: ktlint
+        args: [-F]
+```
+
+
 *Notes*: 
 * This file stores ktlint in a `.cache/` directory so that it doesn't need to be re-downloaded each time.  You will probably want to add `.cache/` to the `.gitignore` file of the project which uses this hook.
 * The first time this hook runs it will need to download ktlint, which takes a

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Usage:
 ```
 repos:
 - repo: https://github.com/maltzj/ktlint-pre-commit
-  sha: e5bee17 
+  sha: master
   hooks:
       - id: ktlint
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Usage:
 ```
 repos:
 - repo: https://github.com/maltzj/ktlint-pre-commit
-  sha: master
+  rev: master
   hooks:
       - id: ktlint
 ```
@@ -15,7 +15,7 @@ If you want to make use of the formatting functionality of ktlint you can config
 the hook as follows:
 repos:
 - repo: https://github.com/maltzj/ktlint-pre-commit
-  sha: master
+  rev: master
   hooks:
       - id: ktlint
         args: [-F]

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -13,6 +13,4 @@ then
     chmod 755 "${KTLINT}"
 fi
 
-changed_kotlin_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*kt$" )
-echo $changed_kotlin_files
-${KTLINT} changed_kotlin_files
+${KTLINT} $*

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -8,7 +8,8 @@ KTLINT="${CACHE}/ktlint-${VERSION}"
 mkdir -p "${CACHE}"
 if [ ! -f "${KTLINT}" ]
 then
-    curl -SLf "${REPOSITORY}/releases/download/$VERSION/ktlint" > "${KTLINT}"
+    echo "Installing ${KTLINT}"
+    curl -#SLf "${REPOSITORY}/releases/download/$VERSION/ktlint" > "${KTLINT}"
     chmod 755 "${KTLINT}"
 fi
 

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -2,17 +2,16 @@
 
 REPOSITORY="https://github.com/pinterest/ktlint"
 VERSION=0.36.0
-KTLINT="ktlint-${VERSION}"
+CACHE=".cache"
+KTLINT="${CACHE}/ktlint-${VERSION}"
 
-mkdir -p .cache
-cd .cache
+mkdir -p "${CACHE}"
 if [ ! -f "${KTLINT}" ]
 then
     curl -SLf "${REPOSITORY}/releases/download/$VERSION/ktlint" > "${KTLINT}"
     chmod 755 "${KTLINT}"
 fi
-cd ..
 
 changed_kotlin_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*kt$" )
 echo $changed_kotlin_files
-.cache/${KTLINT} changed_kotlin_files
+${KTLINT} changed_kotlin_files

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -3,7 +3,7 @@ mkdir -p .cache
 cd .cache
 if [ ! -f ktlint ]
 then
-    curl -sSLO https://github.com/shyiko/ktlint/releases/download/0.29.0/ktlint
+    curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.36.0/ktlint
     chmod 755 ktlint
 fi
 cd ..

--- a/run-ktlint.sh
+++ b/run-ktlint.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env sh
+
+REPOSITORY="https://github.com/pinterest/ktlint"
+VERSION=0.36.0
+KTLINT="ktlint-${VERSION}"
+
 mkdir -p .cache
 cd .cache
-if [ ! -f ktlint ]
+if [ ! -f "${KTLINT}" ]
 then
-    curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.36.0/ktlint
-    chmod 755 ktlint
+    curl -SLf "${REPOSITORY}/releases/download/$VERSION/ktlint" > "${KTLINT}"
+    chmod 755 "${KTLINT}"
 fi
 cd ..
 
 changed_kotlin_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*kt$" )
 echo $changed_kotlin_files
-.cache/ktlint $changed_kotlin_files
+.cache/${KTLINT} changed_kotlin_files


### PR DESCRIPTION
This updates the ktlint release to the current latest (0.36.0), which also reflects that the repository has been moved to the pinterest organization.

Additionally by using the simply forwarding the inputs to the run script to ktlint we make sure that pre-commit handles all the logic to determine which files should be checked. With this running partial checks is still the default, but we can now for example use the `args` property to configure ktlint (e.g. to formatting mode) or run the hook on all files with `pre-commit run ktlint -a`.